### PR TITLE
Changed to "write" method as "save" doesnt exist

### DIFF
--- a/azure-data-lake-storage-gen2-introduction/adlsg2-databricks-demo.scala
+++ b/azure-data-lake-storage-gen2-introduction/adlsg2-databricks-demo.scala
@@ -26,4 +26,4 @@ val df = spark.read.option("header", "true").csv("/mnt/data/demo/movies.csv")
 
 val selected = df.select("movieId", "title")
 
-selected.save.csv("/mnt/data/demo/movies-2.csv")
+selected.write.csv("/mnt/data/demo/movies-2.csv")


### PR DESCRIPTION
Changed selected.save to selected.write as the former results in an error : "save is not a member of org.apache.spark.sql.DataFrame"